### PR TITLE
Extensions of the KCD format to handle CAN-FD messages

### DIFF
--- a/Kayak-kcd/src/main/resources/com/github/kayak/canio/kcd/loader/Definition.xsd
+++ b/Kayak-kcd/src/main/resources/com/github/kayak/canio/kcd/loader/Definition.xsd
@@ -184,9 +184,9 @@
           <xs:documentation>True, if frame formats of the network message supports flexible data rate (dual bit rate).</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-       <xs:attribute name="switchbitrate" use="optional" type="xs:boolean" default="false">
+      <xs:attribute name="bitrateswitch" use="optional" type="xs:boolean" default="false">
         <xs:annotation>
-          <xs:documentation>True, if the alternative bitrate shall be applied in the data phase of transmission i.e. a higher bitrate should be used to send the payload of message. Only allowed for CAN-FD messages. It is an error, if switchbitrate=true and fd=false</xs:documentation>
+			<xs:documentation>True, if this CAN-FD message is sent with the BRS (bit-rate switch) bit set, i.e. a higher bitrate should be used to send the payload of the message. Setting this to bitrateswitch="true", if canfd="false" or canfd unset (default), is an error.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="remote" use="optional" type="xs:boolean" default="false">
@@ -502,7 +502,7 @@
       <xs:simpleType>
         <xs:restriction base="xs:positiveInteger">
           <xs:minInclusive value="1"/>
-          <xs:maxInclusive value="64"/>
+          <xs:maxInclusive value="512"/>
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
@@ -518,7 +518,7 @@
       <xs:simpleType>
         <xs:restriction base="xs:nonNegativeInteger">
           <xs:minInclusive value="0"/>
-          <xs:maxInclusive value="63"/>
+          <xs:maxInclusive value="511"/>
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>

--- a/Kayak-kcd/src/main/resources/com/github/kayak/canio/kcd/loader/Definition.xsd
+++ b/Kayak-kcd/src/main/resources/com/github/kayak/canio/kcd/loader/Definition.xsd
@@ -117,7 +117,7 @@
       </xs:attribute>
       <xs:attribute name="length" use="optional" default="auto">
         <xs:annotation>
-          <xs:documentation>Number of bytes available in the data field of the message (data length code). "auto" (default) calculate minimum length for the contained signals in the message.</xs:documentation>
+          <xs:documentation>Number of bytes available in the data field of the message (data length code). "auto" (default) calculate minimum length for the contained signals in the message. Length greater than 8 is only allowed in messages with flexible data rate (fd).</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:token">
@@ -131,6 +131,13 @@
             <xs:enumeration value="6"/>
             <xs:enumeration value="7"/>
             <xs:enumeration value="8"/>
+            <xs:enumeration value="12"/>
+            <xs:enumeration value="16"/>
+            <xs:enumeration value="20"/>
+            <xs:enumeration value="24"/>
+            <xs:enumeration value="32"/>
+            <xs:enumeration value="48"/>
+            <xs:enumeration value="64"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
@@ -152,7 +159,7 @@
       </xs:attribute>
       <xs:attribute default="0" name="count">
         <xs:annotation>
-          <xs:documentation>Number of repetitions of a triggered network message. 0 (default) for infine repetitions.</xs:documentation>
+          <xs:documentation>Number of repetitions of a triggered network message. 0 (default) for infinite repetitions.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:nonNegativeInteger">
@@ -172,9 +179,19 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>
+      <xs:attribute name="fd" use="optional" type="xs:boolean" default="false">
+        <xs:annotation>
+          <xs:documentation>True, if frame formats of the network message supports flexible data rate (dual bit rate).</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+       <xs:attribute name="switchbitrate" use="optional" type="xs:boolean" default="false">
+        <xs:annotation>
+          <xs:documentation>True, if the alternative bitrate shall be applied in the data phase of transmission i.e. a higher bitrate should be used to send the payload of message. Only allowed for CAN-FD messages. It is an error, if switchbitrate=true and fd=false</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="remote" use="optional" type="xs:boolean" default="false">
         <xs:annotation>
-          <xs:documentation>True, if message is a remote frame.</xs:documentation>
+          <xs:documentation>True, if message is a remote frame. Not possible in messages with flexible data rate (fd).</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 Kayak
 =====
 
-Kayak is a application for CAN bus diagnosis and monitoring. Its main goals are a simple interface and platform independence.
+[Kayak](https://github.com/dschanoeh/Kayak) is an application for CAN bus diagnosis and monitoring. Its main goals are a simple interface and platform independence.
 Kayak is implemented in pure Java and has no platform specific dependencies. It includes a complete CAN bus abstraction model that can be included in other applications that need do handle CAN frames.
-This is possible because [Socket CAN](http://developer.berlios.de/projects/socketcan/) and TCP/IP are used as an abstraction layer above the CAN controller hardware.
+This is possible because [Socket CAN](https://gitorious.org/linux-can) and TCP/IP are used as an abstraction layer above the CAN controller hardware.
 The [socketcand](https://github.com/dschanoeh/socketcand) provides the bridge between the Socket CAN device on a linux machine and the TCP/IP socket of Kayak.
 Existing .dbc files with CAN message specifications can be converted into the Kayak .kcd format using [CANBabel](https://github.com/julietkilo/CANBabel). Afterwards Kayak is able to decode CAN frames and to display and interpret the messages and signals.
 To build Kayak follow the instructions in BUILD.md
 
 ### What is implemented yet:
 * abstract bus, receiver, sender - model
-* .kcd bus description format
+* .kcd bus description format, see [CANBabel](https://github.com/julietkilo/CANBabel)
 * project and log file management
 * simple raw view of CAN frames
 * sending of single and repetitive CAN frames


### PR DESCRIPTION
CANBabel has been completely revised to support databases containing CAN-FD messages.